### PR TITLE
Kvs

### DIFF
--- a/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreQueryActionProcessor.ts
+++ b/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreQueryActionProcessor.ts
@@ -11,7 +11,7 @@ import { query } from '../../../logic/dynamo';
 const getProcessKeyValueStoreQuery = (
   qpqConfig: QPQConfig,
 ): KeyValueStoreQueryActionProcessor<any> => {
-  return async ({ keyValueStoreName, operations }) => {
+  return async ({ keyValueStoreName }) => {
     const dynamoTableName = getQpqRuntimeResourceNameFromConfig(
       keyValueStoreName,
       qpqConfig,

--- a/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreQueryActionProcessor.ts
+++ b/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreQueryActionProcessor.ts
@@ -7,11 +7,12 @@ import {
   KeyValueStoreActionType,
 } from 'quidproquo-core';
 import { query } from '../../../logic/dynamo';
+import { getDynamoTableIndexByConfigAndQuery } from '../../../logic/dynamo/qpqDynamoOrm/thing';
 
 const getProcessKeyValueStoreQuery = (
   qpqConfig: QPQConfig,
 ): KeyValueStoreQueryActionProcessor<any> => {
-  return async ({ keyValueStoreName }) => {
+  return async ({ keyValueStoreName, keyCondition, filterCondition }) => {
     const dynamoTableName = getQpqRuntimeResourceNameFromConfig(
       keyValueStoreName,
       qpqConfig,
@@ -27,9 +28,15 @@ const getProcessKeyValueStoreQuery = (
       );
     }
 
-    await query(dynamoTableName, region);
+    const items = await query(
+      dynamoTableName,
+      region,
+      keyCondition,
+      filterCondition,
+      getDynamoTableIndexByConfigAndQuery(storeConfig, keyCondition),
+    );
 
-    return actionResult([]);
+    return actionResult(items);
   };
 };
 

--- a/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreQueryActionProcessor.ts
+++ b/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreQueryActionProcessor.ts
@@ -1,0 +1,38 @@
+import { QPQConfig, qpqCoreUtils, actionResultError, ErrorTypeEnum } from 'quidproquo-core';
+
+import { getQpqRuntimeResourceNameFromConfig } from '../../../awsNamingUtils';
+import {
+  KeyValueStoreQueryActionProcessor,
+  actionResult,
+  KeyValueStoreActionType,
+} from 'quidproquo-core';
+import { query } from '../../../logic/dynamo';
+
+const getProcessKeyValueStoreQuery = (
+  qpqConfig: QPQConfig,
+): KeyValueStoreQueryActionProcessor<any> => {
+  return async ({ keyValueStoreName, operations }) => {
+    const dynamoTableName = getQpqRuntimeResourceNameFromConfig(
+      keyValueStoreName,
+      qpqConfig,
+      'kvs',
+    );
+    const region = qpqCoreUtils.getApplicationModuleDeployRegion(qpqConfig);
+
+    const storeConfig = qpqCoreUtils.getKeyValueStoreByName(qpqConfig, keyValueStoreName);
+    if (!storeConfig) {
+      return actionResultError(
+        ErrorTypeEnum.NotFound,
+        `Could not find key value store with name "${keyValueStoreName}"`,
+      );
+    }
+
+    await query(dynamoTableName, region);
+
+    return actionResult([]);
+  };
+};
+
+export default (qpqConfig: QPQConfig) => ({
+  [KeyValueStoreActionType.Query]: getProcessKeyValueStoreQuery(qpqConfig),
+});

--- a/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreScanActionProcessor.ts
+++ b/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreScanActionProcessor.ts
@@ -1,0 +1,38 @@
+import { QPQConfig, qpqCoreUtils, actionResultError, ErrorTypeEnum } from 'quidproquo-core';
+
+import { getQpqRuntimeResourceNameFromConfig } from '../../../awsNamingUtils';
+import {
+  KeyValueStoreScanActionProcessor,
+  actionResult,
+  KeyValueStoreActionType,
+} from 'quidproquo-core';
+import { scan } from '../../../logic/dynamo/scan';
+
+const getProcessKeyValueStoreScan = (
+  qpqConfig: QPQConfig,
+): KeyValueStoreScanActionProcessor<any> => {
+  return async ({ keyValueStoreName, filterCondition }) => {
+    const dynamoTableName = getQpqRuntimeResourceNameFromConfig(
+      keyValueStoreName,
+      qpqConfig,
+      'kvs',
+    );
+    const region = qpqCoreUtils.getApplicationModuleDeployRegion(qpqConfig);
+
+    const storeConfig = qpqCoreUtils.getKeyValueStoreByName(qpqConfig, keyValueStoreName);
+    if (!storeConfig) {
+      return actionResultError(
+        ErrorTypeEnum.NotFound,
+        `Could not find key value store with name "${keyValueStoreName}"`,
+      );
+    }
+
+    const items = await scan(dynamoTableName, region, filterCondition);
+
+    return actionResult(items);
+  };
+};
+
+export default (qpqConfig: QPQConfig) => ({
+  [KeyValueStoreActionType.Scan]: getProcessKeyValueStoreScan(qpqConfig),
+});

--- a/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreUpsertActionProcessor.ts
+++ b/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/getKeyValueStoreUpsertActionProcessor.ts
@@ -1,33 +1,53 @@
-import { QPQConfig, qpqCoreUtils } from 'quidproquo-core';
-
-import { getQpqRuntimeResourceNameFromConfig } from '../../../awsNamingUtils';
 import {
+  QPQConfig,
+  qpqCoreUtils,
   KeyValueStoreUpsertActionProcessor,
   actionResult,
   KeyValueStoreActionType,
+  ErrorTypeEnum,
+  actionResultError,
 } from 'quidproquo-core';
+
+import { getQpqRuntimeResourceNameFromConfig } from '../../../awsNamingUtils';
+
 import { putItem } from '../../../logic/dynamo';
 
 const getProcessKeyValueStoreUpsert = (
   qpqConfig: QPQConfig,
 ): KeyValueStoreUpsertActionProcessor<any> => {
   return async ({ keyValueStoreName, item, options }) => {
-    // const dynamoTableName = getQpqRuntimeResourceNameFromConfig(
-    //   keyValueStoreName,
-    //   qpqConfig,
-    //   'kvs',
-    // );
-    // const region = qpqCoreUtils.getApplicationModuleDeployRegion(qpqConfig);
+    console.log('HERE!');
+    const dynamoTableName = getQpqRuntimeResourceNameFromConfig(
+      keyValueStoreName,
+      qpqConfig,
+      'kvs',
+    );
+    const region = qpqCoreUtils.getApplicationModuleDeployRegion(qpqConfig);
 
-    // await putItem(
-    //   dynamoTableName,
-    //   key,
-    //   value,
-    //   {
-    //     expires: options?.ttlInSeconds,
-    //   },
-    //   region,
-    // );
+    const storeConfig = qpqCoreUtils.getKeyValueStoreByName(qpqConfig, keyValueStoreName);
+    if (!storeConfig) {
+      return actionResultError(
+        ErrorTypeEnum.NotFound,
+        `Could not find key value store with name "${keyValueStoreName}"`,
+      );
+    }
+
+    const keys = [
+      storeConfig.partitionKey,
+      ...storeConfig.sortKeys,
+      ...storeConfig.indexes.map((i) => i.partitionKey),
+      ...storeConfig.indexes.filter((i) => !!i.sortKey).map((i) => i.sortKey!),
+    ];
+
+    await putItem(
+      dynamoTableName,
+      item,
+      keys,
+      {
+        expires: options?.ttlInSeconds,
+      },
+      region,
+    );
 
     return actionResult(void 0);
   };

--- a/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/index.ts
+++ b/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/index.ts
@@ -4,10 +4,12 @@ import getKeyValueStoreDeleteActionProcessor from './getKeyValueStoreDeleteActio
 import getKeyValueStoreGetActionProcessor from './getKeyValueStoreGetActionProcessor';
 import getKeyValueStoreUpsertActionProcessor from './getKeyValueStoreUpsertActionProcessor';
 import getKeyValueStoreUpdateActionProcessor from './getKeyValueStoreUpdateActionProcessor';
+import getKeyValueStoreQueryActionProcessor from './getKeyValueStoreQueryActionProcessor';
 
 export default (qpqConfig: QPQConfig) => ({
   ...getKeyValueStoreDeleteActionProcessor(qpqConfig),
   ...getKeyValueStoreGetActionProcessor(qpqConfig),
-  ...getKeyValueStoreUpsertActionProcessor(qpqConfig),
+  ...getKeyValueStoreQueryActionProcessor(qpqConfig),
   ...getKeyValueStoreUpdateActionProcessor(qpqConfig),
+  ...getKeyValueStoreUpsertActionProcessor(qpqConfig),
 });

--- a/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/index.ts
+++ b/quidproquo-actionprocessor-awslambda/src/getActionProcessor/core/keyValueStore/index.ts
@@ -5,6 +5,7 @@ import getKeyValueStoreGetActionProcessor from './getKeyValueStoreGetActionProce
 import getKeyValueStoreUpsertActionProcessor from './getKeyValueStoreUpsertActionProcessor';
 import getKeyValueStoreUpdateActionProcessor from './getKeyValueStoreUpdateActionProcessor';
 import getKeyValueStoreQueryActionProcessor from './getKeyValueStoreQueryActionProcessor';
+import getKeyValueStoreScanActionProcessor from './getKeyValueStoreScanActionProcessor';
 
 export default (qpqConfig: QPQConfig) => ({
   ...getKeyValueStoreDeleteActionProcessor(qpqConfig),
@@ -12,4 +13,5 @@ export default (qpqConfig: QPQConfig) => ({
   ...getKeyValueStoreQueryActionProcessor(qpqConfig),
   ...getKeyValueStoreUpdateActionProcessor(qpqConfig),
   ...getKeyValueStoreUpsertActionProcessor(qpqConfig),
+  ...getKeyValueStoreScanActionProcessor(qpqConfig),
 });

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/convertObjectToDynamoMap.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/convertObjectToDynamoMap.ts
@@ -39,3 +39,37 @@ export function convertObjectToDynamoMap(obj: any) {
 
   return map;
 }
+
+export function convertDynamoMapToObject(dynamoMap: any): any {
+  const obj: any = {};
+
+  for (const property in dynamoMap) {
+    const value = dynamoMap[property];
+    const valueType = Object.keys(value)[0];
+
+    switch (valueType) {
+      case 'S':
+        obj[property] = value.S;
+        break;
+      case 'N':
+        obj[property] = parseFloat(value.N);
+        break;
+      case 'BOOL':
+        obj[property] = value.BOOL;
+        break;
+      case 'NULL':
+        obj[property] = null;
+        break;
+      case 'L':
+        obj[property] = value.L.map((item: any) => convertDynamoMapToObject({ temp: item }).temp);
+        break;
+      case 'M':
+        obj[property] = convertDynamoMapToObject(value.M);
+        break;
+      default:
+        throw new Error(`Unsupported DynamoDB data type: ${valueType}`);
+    }
+  }
+
+  return obj;
+}

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/convertObjectToDynamoMap.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/convertObjectToDynamoMap.ts
@@ -1,0 +1,41 @@
+export function convertObjectToDynamoMap(obj: any) {
+  const map: any = {};
+
+  for (const property in obj) {
+    console.log('starting', property);
+
+    const value = obj[property];
+    const valueType = typeof value;
+
+    console.log({ property, value, valueType });
+
+    switch (valueType) {
+      case 'string':
+        map[property] = { S: value };
+        break;
+      case 'number':
+        map[property] = { N: value.toString() };
+        break;
+      case 'boolean':
+        map[property] = { BOOL: value };
+        break;
+      case 'object':
+        if (Array.isArray(value)) {
+          map[property] = {
+            L: value.map((item) => convertObjectToDynamoMap({ temp: item }).temp),
+          };
+        } else if (value !== null) {
+          map[property] = { M: convertObjectToDynamoMap(value) };
+        } else {
+          map[property] = { NULL: true };
+        }
+        break;
+      default:
+        throw new Error(`Unsupported data type: ${valueType}`);
+    }
+
+    console.log('ending', property);
+  }
+
+  return map;
+}

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/convertObjectToDynamoMap.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/convertObjectToDynamoMap.ts
@@ -2,12 +2,8 @@ export function convertObjectToDynamoMap(obj: any) {
   const map: any = {};
 
   for (const property in obj) {
-    console.log('starting', property);
-
     const value = obj[property];
     const valueType = typeof value;
-
-    console.log({ property, value, valueType });
 
     switch (valueType) {
       case 'string':
@@ -33,8 +29,6 @@ export function convertObjectToDynamoMap(obj: any) {
       default:
         throw new Error(`Unsupported data type: ${valueType}`);
     }
-
-    console.log('ending', property);
   }
 
   return map;

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/index.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/index.ts
@@ -3,3 +3,4 @@ export * from './getAllItems';
 export * from './getItem';
 export * from './putItem';
 export * from './updateItem';
+export * from './query';

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/putItem.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/putItem.ts
@@ -63,12 +63,7 @@ export async function putItem<Item>(
   await dynamoClient.send(
     new PutItemCommand({
       TableName: tableName,
-      Item: {
-        ...dynamoProps,
-        ['__qpq-data']: {
-          M: convertObjectToDynamoMap(item),
-        },
-      },
+      Item: convertObjectToDynamoMap(item),
     }),
   );
 }

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/putItem.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/putItem.ts
@@ -1,6 +1,7 @@
 import { KvsKey } from 'quidproquo-core';
 import { DynamoDBClient, PutItemCommand, AttributeValue } from '@aws-sdk/client-dynamodb';
 import { get } from 'lodash';
+import { convertObjectToDynamoMap } from './convertObjectToDynamoMap';
 
 export interface PutItemOptions {
   expires?: number;
@@ -38,7 +39,6 @@ export const getDynamoValueTypeFromKvsKey = (key: KvsKey): DynamoAttributeType =
 
 export async function putItem<Item>(
   tableName: string,
-  key: string,
   item: Item,
   attributes: KvsKey[],
   options: PutItemOptions,
@@ -65,6 +65,9 @@ export async function putItem<Item>(
       TableName: tableName,
       Item: {
         ...dynamoProps,
+        ['__qpq-data']: {
+          M: convertObjectToDynamoMap(item),
+        },
       },
     }),
   );

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/buildDynamoQuery.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/buildDynamoQuery.ts
@@ -15,17 +15,15 @@ import { AttributeValue } from '@aws-sdk/client-dynamodb';
 
 const getHash = (name: string): string => {
   const c = crypto.createHash('md5').update(name).digest('hex');
-  console.log(`Hash for ${name} is ${c}`);
+
   return c;
 };
 
 const getItemName = (name: string) => {
-  console.log('item name');
   return `#${getHash(name)}`;
 };
 
 const getValueName = (value: string | number | boolean | string[]) => {
-  console.log('item value');
   return `:${getHash(`${typeof value}-${JSON.stringify(value)}`)}`;
 };
 

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/buildDynamoQuery.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/buildDynamoQuery.ts
@@ -1,0 +1,227 @@
+import crypto from 'crypto';
+
+import {
+  KvsQueryOperation,
+  KvsQueryOperationType,
+  KvsQueryCondition,
+  KvsLogicalOperator,
+  KvsLogicalOperatorType,
+} from 'quidproquo-core';
+
+import { AttributeValue } from '@aws-sdk/client-dynamodb';
+
+// TODO: Come up with a better way of generating item name / values
+// probably a map ~ however this will most likely never fail.
+
+const getHash = (name: string): string => {
+  const c = crypto.createHash('md5').update(name).digest('hex');
+  console.log(`Hash for ${name} is ${c}`);
+  return c;
+};
+
+const getItemName = (name: string) => {
+  console.log('item name');
+  return `#${getHash(name)}`;
+};
+
+const getValueName = (value: string | number | boolean | string[]) => {
+  console.log('item value');
+  return `:${getHash(`${typeof value}-${JSON.stringify(value)}`)}`;
+};
+
+const buildDynamoQueryExpressionBetween = (query: KvsQueryCondition): string => {
+  if (!query.key || !query.valueB || !query.valueB) {
+    throw new Error(`Invalid query condition ${KvsQueryOperationType.Between}`);
+  }
+
+  return `${getItemName(query.key)} BETWEEN ${getValueName(
+    query.valueA as string,
+  )} AND ${getValueName(query.valueB as string)}`;
+};
+
+const buildDynamoQueryExpressionEqual = (query: KvsQueryCondition): string => {
+  return `${getItemName(query.key)} = ${getValueName(query.valueA as string)}`;
+};
+
+const buildDynamoQueryExpressionNotEqual = (query: KvsQueryCondition): string => {
+  return `${getItemName(query.key)} <> ${getValueName(query.valueA as string)}`;
+};
+
+const buildDynamoQueryExpressionLessThan = (query: KvsQueryCondition): string => {
+  return `${getItemName(query.key)} < ${getValueName(query.valueA as string)}`;
+};
+
+const buildDynamoQueryExpressionLessThanOrEqual = (query: KvsQueryCondition): string => {
+  return `${getItemName(query.key)} <= ${getValueName(query.valueA as string)}`;
+};
+
+const buildDynamoQueryExpressionGreaterThan = (query: KvsQueryCondition): string => {
+  return `${getItemName(query.key)} > ${getValueName(query.valueA as string)}`;
+};
+
+const buildDynamoQueryExpressionGreaterThanOrEqual = (query: KvsQueryCondition): string => {
+  return `${getItemName(query.key)} >= ${getValueName(query.valueA as string)}`;
+};
+
+const buildDynamoQueryExpressionIn = (query: KvsQueryCondition): string => {
+  return `${getItemName(query.key)} IN (${(query.valueA as string[])
+    .map((v) => getValueName(v))
+    .join(', ')})`;
+};
+
+const buildDynamoQueryExpressionExists = (query: KvsQueryCondition): string => {
+  return `attribute_exists(${getItemName(query.key)})`;
+};
+
+const buildDynamoQueryExpressionNotExists = (query: KvsQueryCondition): string => {
+  return `attribute_not_exists(${getItemName(query.key)})`;
+};
+
+const buildDynamoQueryExpressionBeginsWith = (query: KvsQueryCondition): string => {
+  return `begins_with(${getItemName(query.key)}, ${getValueName(query.valueA as string)})`;
+};
+
+const buildDynamoQueryExpressionContains = (query: KvsQueryCondition): string => {
+  return `contains(${getItemName(query.key)}, ${getValueName(query.valueA as string)})`;
+};
+
+const buildDynamoQueryExpressionNotContains = (query: KvsQueryCondition): string => {
+  return `NOT contains(${getItemName(query.key)}, ${getValueName(query.valueA as string)})`;
+};
+
+const buildDynamoQueryExpressionOr = (query: KvsLogicalOperator): string => {
+  return query.conditions.map((c) => `(${buildDynamoQueryExpressionRoot(c)})`).join(' OR ');
+};
+
+const buildDynamoQueryExpressionAnd = (query: KvsLogicalOperator): string => {
+  return query.conditions.map((c) => `(${buildDynamoQueryExpressionRoot(c)})`).join(' AND ');
+};
+
+export const isKvsQueryCondition = (query: KvsQueryOperation): query is KvsQueryCondition => {
+  return 'key' in query && 'operation' in query;
+};
+
+export const isKvsLogicalOperator = (query: KvsQueryOperation): query is KvsLogicalOperator => {
+  return 'conditions' in query && 'operation' in query;
+};
+
+const buildDynamoQueryExpressionRoot = (query: KvsQueryOperation): string => {
+  if (isKvsQueryCondition(query)) {
+    switch (query.operation) {
+      case KvsQueryOperationType.Equal:
+        return buildDynamoQueryExpressionEqual(query);
+      case KvsQueryOperationType.NotEqual:
+        return buildDynamoQueryExpressionNotEqual(query);
+      case KvsQueryOperationType.LessThan:
+        return buildDynamoQueryExpressionLessThan(query);
+      case KvsQueryOperationType.LessThanOrEqual:
+        return buildDynamoQueryExpressionLessThanOrEqual(query);
+      case KvsQueryOperationType.GreaterThan:
+        return buildDynamoQueryExpressionGreaterThan(query);
+      case KvsQueryOperationType.GreaterThanOrEqual:
+        return buildDynamoQueryExpressionGreaterThanOrEqual(query);
+      case KvsQueryOperationType.Between:
+        return buildDynamoQueryExpressionBetween(query);
+      case KvsQueryOperationType.In:
+        return buildDynamoQueryExpressionIn(query);
+      case KvsQueryOperationType.Exists:
+        return buildDynamoQueryExpressionExists(query);
+      case KvsQueryOperationType.NotExists:
+        return buildDynamoQueryExpressionNotExists(query);
+      case KvsQueryOperationType.BeginsWith:
+        return buildDynamoQueryExpressionBeginsWith(query);
+      case KvsQueryOperationType.Contains:
+        return buildDynamoQueryExpressionContains(query);
+      case KvsQueryOperationType.NotContains:
+        return buildDynamoQueryExpressionNotContains(query);
+    }
+  } else if (isKvsLogicalOperator(query)) {
+    switch (query.operation) {
+      case KvsLogicalOperatorType.And:
+        return buildDynamoQueryExpressionAnd(query);
+      case KvsLogicalOperatorType.Or:
+        return buildDynamoQueryExpressionOr(query);
+    }
+  }
+
+  throw new Error(`Invalid query operation: ${JSON.stringify(query)}`);
+};
+
+const buildAttributeValue = (value: string | number | boolean | string[]): AttributeValue => {
+  switch (typeof value) {
+    case 'string':
+      return { S: value };
+    case 'number':
+      return { N: value.toString() };
+    case 'boolean':
+      return { BOOL: value };
+    case 'object':
+      if (Array.isArray(value)) {
+        // check if all elements in the array are strings
+        if (value.every((item) => typeof item === 'string')) {
+          return { L: value.map((item) => ({ S: item })) };
+        }
+        throw new Error(`Invalid attribute value array content: ${JSON.stringify(value)}`);
+      }
+      throw new Error(`Invalid attribute value type: ${typeof value}`);
+    default:
+      throw new Error(`Invalid attribute value type: ${typeof value}`);
+  }
+};
+
+export const buildDynamoQueryExpression = (query?: KvsQueryOperation): string | undefined => {
+  if (!query) {
+    return undefined;
+  }
+
+  return buildDynamoQueryExpressionRoot(query);
+};
+
+export const buildExpressionAttributeValues = (
+  queries: (KvsQueryOperation | undefined)[],
+): Record<string, AttributeValue> => {
+  const values: Record<string, AttributeValue> = {};
+
+  const traverse = (query: KvsQueryOperation) => {
+    if (isKvsQueryCondition(query)) {
+      if (query.valueA !== undefined) {
+        const valueNameA = getValueName(query.valueA);
+        values[valueNameA] = buildAttributeValue(query.valueA);
+      }
+
+      if (query.valueB !== undefined) {
+        const valueNameB = getValueName(query.valueB);
+        values[valueNameB] = buildAttributeValue(query.valueB);
+      }
+    } else if (isKvsLogicalOperator(query)) {
+      for (const condition of query.conditions) {
+        traverse(condition);
+      }
+    }
+  };
+
+  queries.filter((q) => !!q).forEach((q) => traverse(q!));
+
+  return values;
+};
+
+export const buildExpressionAttributeNames = (
+  queries: (KvsQueryOperation | undefined)[],
+): Record<string, string> => {
+  const names: Record<string, string> = {};
+
+  const traverse = (query: KvsQueryOperation) => {
+    if (isKvsQueryCondition(query)) {
+      const itemName = getItemName(query.key);
+      names[itemName] = query.key;
+    } else if (isKvsLogicalOperator(query)) {
+      for (const condition of query.conditions) {
+        traverse(condition);
+      }
+    }
+  };
+
+  queries.filter((q) => !!q).forEach((q) => traverse(q!));
+
+  return names;
+};

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/index.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/index.ts
@@ -1,0 +1,1 @@
+export * from './buildDynamoQuery';

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/thing.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/qpqDynamoOrm/thing.ts
@@ -1,0 +1,29 @@
+import { KeyValueStoreQPQConfigSetting, KvsQueryOperation } from 'quidproquo-core';
+import { isKvsQueryCondition, isKvsLogicalOperator } from './buildDynamoQuery';
+
+export const getDynamoTableIndexByConfigAndQuery = (
+  setting: KeyValueStoreQPQConfigSetting,
+  query: KvsQueryOperation,
+): string | undefined => {
+  // Function to extract keys from a query
+  const extractKeysFromQuery = (query: KvsQueryOperation): string[] => {
+    if (isKvsQueryCondition(query)) {
+      return [query.key];
+    } else if (isKvsLogicalOperator(query)) {
+      return query.conditions.flatMap(extractKeysFromQuery);
+    }
+    return [];
+  };
+
+  const queriedKeys = extractKeysFromQuery(query);
+
+  // Find a matching index
+  for (const index of setting.indexes) {
+    if (queriedKeys.includes(index.partitionKey.key)) {
+      return index.partitionKey.key;
+    }
+  }
+
+  // No matching index found
+  return undefined;
+};

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/query.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/query.ts
@@ -28,6 +28,7 @@ export async function query<Item>(
     IndexName: indexName,
   };
 
+  // TODO: Remove this log
   console.log(params);
 
   // Create QueryCommand

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/query.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/query.ts
@@ -1,0 +1,54 @@
+import {
+  DynamoDBClient,
+  QueryCommand,
+  QueryCommandInput,
+  AttributeValue,
+} from '@aws-sdk/client-dynamodb';
+
+export async function query<Item>(tableName: string, region: string): Promise<void> {
+  // Instantiate DynamoDB client
+  const dynamoClient = new DynamoDBClient({ region });
+
+  // Define query parameters
+  // const params: QueryCommandInput = {
+  //   TableName: tableName,
+  //   // KeyConditionExpression: '#id = :idValue',
+  //   FilterExpression: 'begins_with(test.#ok, :okValue)',
+  //   ExpressionAttributeValues: {
+  //     // ':idValue': { S: '1234' },
+  //     ':okValue': { S: '11' },
+  //   },
+  //   ExpressionAttributeNames: {
+  //     // '#test': 'test',
+  //     '#ok': 'ok',
+  //   },
+  //   // ProjectionExpression: '#test.#ok',
+  // };
+
+  const params: QueryCommandInput = {
+    TableName: tableName,
+    // KeyConditionExpression: '#id = :idValue',
+    KeyConditionExpression:
+      '((#id = :idValueA) AND (#startedAt BETWEEN :startedAtValueA AND :startedAtValueB))',
+    ExpressionAttributeValues: {
+      ':idValueA': { S: '1234' },
+      ':startedAtValueA': { S: '2023-05-23T04:12:17.000Z' },
+      ':startedAtValueB': { S: '2023-05-23T04:12:39.000Z' },
+    },
+    ExpressionAttributeNames: {
+      '#startedAt': 'startedAt',
+      '#id': 'id',
+    },
+  };
+
+  // Create QueryCommand
+  const command = new QueryCommand(params);
+
+  try {
+    // Send the QueryCommand
+    const data = await dynamoClient.send(command);
+    console.log('Success', JSON.stringify(data.Items, null, 2));
+  } catch (error) {
+    console.error('Error', error);
+  }
+}

--- a/quidproquo-actionprocessor-awslambda/src/logic/dynamo/scan.ts
+++ b/quidproquo-actionprocessor-awslambda/src/logic/dynamo/scan.ts
@@ -1,0 +1,36 @@
+import { DynamoDBClient, ScanCommand, ScanCommandInput } from '@aws-sdk/client-dynamodb';
+
+import { KvsQueryOperation } from 'quidproquo-core';
+import { convertDynamoMapToObject } from './convertObjectToDynamoMap';
+
+import {
+  buildExpressionAttributeValues,
+  buildExpressionAttributeNames,
+  buildDynamoQueryExpression,
+} from './qpqDynamoOrm';
+
+export async function scan<Item>(
+  tableName: string,
+  region: string,
+  filterExpression?: KvsQueryOperation,
+): Promise<Item[]> {
+  // Instantiate DynamoDB client
+  const dynamoClient = new DynamoDBClient({ region });
+
+  const params: ScanCommandInput = {
+    TableName: tableName,
+    FilterExpression: buildDynamoQueryExpression(filterExpression),
+    ExpressionAttributeValues: buildExpressionAttributeValues([filterExpression]),
+    ExpressionAttributeNames: buildExpressionAttributeNames([filterExpression]),
+  };
+
+  console.log(params);
+
+  // Create ScanCommand
+  const command = new ScanCommand(params);
+
+  // TODO: Catch errors and throw QPQ ones
+  const data = await dynamoClient.send(command);
+
+  return (data.Items?.map((i) => convertDynamoMapToObject(i)) || []) as Item[];
+}

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreActionType.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreActionType.ts
@@ -5,4 +5,5 @@ export enum KeyValueStoreActionType {
   Delete = '@quidproquo-core/KeyValueStore/Delete',
   Update = '@quidproquo-core/KeyValueStore/Update',
   Query = '@quidproquo-core/KeyValueStore/Query',
+  Scan = '@quidproquo-core/KeyValueStore/Scan',
 }

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreActionType.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreActionType.ts
@@ -4,4 +4,5 @@ export enum KeyValueStoreActionType {
   GetAll = '@quidproquo-core/KeyValueStore/GetAll',
   Delete = '@quidproquo-core/KeyValueStore/Delete',
   Update = '@quidproquo-core/KeyValueStore/Update',
+  Query = '@quidproquo-core/KeyValueStore/Query',
 }

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionRequester.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionRequester.ts
@@ -1,0 +1,17 @@
+import { KeyValueStoreActionType } from './KeyValueStoreActionType';
+import { KeyValueStoreQueryActionRequester } from './KeyValueStoreQueryActionTypes';
+
+import { KvsQueryOperation } from './types';
+
+export function* askKeyValueStoreQuery<KvsItem>(
+  keyValueStoreName: string,
+  operations: KvsQueryOperation[],
+): KeyValueStoreQueryActionRequester<KvsItem> {
+  return yield {
+    type: KeyValueStoreActionType.Query,
+    payload: {
+      keyValueStoreName,
+      operations,
+    },
+  };
+}

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionRequester.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionRequester.ts
@@ -5,13 +5,17 @@ import { KvsQueryOperation } from './types';
 
 export function* askKeyValueStoreQuery<KvsItem>(
   keyValueStoreName: string,
-  operations: KvsQueryOperation[],
+
+  keyCondition: KvsQueryOperation,
+  filterCondition?: KvsQueryOperation,
 ): KeyValueStoreQueryActionRequester<KvsItem> {
   return yield {
     type: KeyValueStoreActionType.Query,
     payload: {
       keyValueStoreName,
-      operations,
+
+      keyCondition,
+      filterCondition,
     },
   };
 }

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionTypes.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionTypes.ts
@@ -1,0 +1,32 @@
+import { KeyValueStoreActionType } from './KeyValueStoreActionType';
+import { Action, ActionProcessor, ActionRequester } from '../../types/Action';
+
+import { KvsQueryOperation } from './types';
+
+// Options Type
+export interface KeyValueStoreQueryOptions {
+  ttlInSeconds?: number; // Time-to-live in seconds
+}
+
+// Payload
+export interface KeyValueStoreQueryActionPayload {
+  keyValueStoreName: string;
+
+  operations: KvsQueryOperation[];
+}
+
+// Action
+export interface KeyValueStoreQueryAction extends Action<KeyValueStoreQueryActionPayload> {
+  type: KeyValueStoreActionType.Query;
+  payload: KeyValueStoreQueryActionPayload;
+}
+
+// Function Types
+export type KeyValueStoreQueryActionProcessor<KvsItem> = ActionProcessor<
+  KeyValueStoreQueryAction,
+  KvsItem[]
+>;
+export type KeyValueStoreQueryActionRequester<KvsItem> = ActionRequester<
+  KeyValueStoreQueryAction,
+  KvsItem[]
+>;

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionTypes.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreQueryActionTypes.ts
@@ -12,7 +12,8 @@ export interface KeyValueStoreQueryOptions {
 export interface KeyValueStoreQueryActionPayload {
   keyValueStoreName: string;
 
-  operations: KvsQueryOperation[];
+  keyCondition: KvsQueryOperation;
+  filterCondition?: KvsQueryOperation;
 }
 
 // Action

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreScanActionRequester.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreScanActionRequester.ts
@@ -1,0 +1,19 @@
+import { KeyValueStoreActionType } from './KeyValueStoreActionType';
+import { KeyValueStoreScanActionRequester } from './KeyValueStoreScanActionTypes';
+
+import { KvsQueryOperation } from './types';
+
+export function* askKeyValueStoreScan<KvsItem>(
+  keyValueStoreName: string,
+
+  filterCondition?: KvsQueryOperation,
+): KeyValueStoreScanActionRequester<KvsItem> {
+  return yield {
+    type: KeyValueStoreActionType.Scan,
+    payload: {
+      keyValueStoreName,
+
+      filterCondition,
+    },
+  };
+}

--- a/quidproquo-core/src/actions/keyValueStore/KeyValueStoreScanActionTypes.ts
+++ b/quidproquo-core/src/actions/keyValueStore/KeyValueStoreScanActionTypes.ts
@@ -1,0 +1,32 @@
+import { KeyValueStoreActionType } from './KeyValueStoreActionType';
+import { Action, ActionProcessor, ActionRequester } from '../../types/Action';
+
+import { KvsQueryOperation } from './types';
+
+// Options Type
+export interface KeyValueStoreScanOptions {
+  ttlInSeconds?: number; // Time-to-live in seconds
+}
+
+// Payload
+export interface KeyValueStoreScanActionPayload {
+  keyValueStoreName: string;
+
+  filterCondition?: KvsQueryOperation;
+}
+
+// Action
+export interface KeyValueStoreScanAction extends Action<KeyValueStoreScanActionPayload> {
+  type: KeyValueStoreActionType.Scan;
+  payload: KeyValueStoreScanActionPayload;
+}
+
+// Function Types
+export type KeyValueStoreScanActionProcessor<KvsItem> = ActionProcessor<
+  KeyValueStoreScanAction,
+  KvsItem[]
+>;
+export type KeyValueStoreScanActionRequester<KvsItem> = ActionRequester<
+  KeyValueStoreScanAction,
+  KvsItem[]
+>;

--- a/quidproquo-core/src/actions/keyValueStore/index.ts
+++ b/quidproquo-core/src/actions/keyValueStore/index.ts
@@ -14,6 +14,9 @@ export * from './KeyValueStoreGetAllActionTypes';
 export * from './KeyValueStoreQueryActionRequester';
 export * from './KeyValueStoreQueryActionTypes';
 
+export * from './KeyValueStoreScanActionRequester';
+export * from './KeyValueStoreScanActionTypes';
+
 export * from './KeyValueStoreUpdateActionRequester';
 export * from './KeyValueStoreUpdateActionTypes';
 

--- a/quidproquo-core/src/actions/keyValueStore/index.ts
+++ b/quidproquo-core/src/actions/keyValueStore/index.ts
@@ -1,4 +1,6 @@
 export * from './KeyValueStoreActionType';
+export * from './types';
+export * from './utils';
 
 export * from './KeyValueStoreDeleteActionRequester';
 export * from './KeyValueStoreDeleteActionTypes';
@@ -8,6 +10,9 @@ export * from './KeyValueStoreGetActionTypes';
 
 export * from './KeyValueStoreGetAllActionRequester';
 export * from './KeyValueStoreGetAllActionTypes';
+
+export * from './KeyValueStoreQueryActionRequester';
+export * from './KeyValueStoreQueryActionTypes';
 
 export * from './KeyValueStoreUpdateActionRequester';
 export * from './KeyValueStoreUpdateActionTypes';

--- a/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperation.ts
+++ b/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperation.ts
@@ -1,8 +1,18 @@
-import { KvsQueryOperationType } from './KvsQueryOperationType';
+import { KvsQueryOperationType, KvsLogicalOperatorType } from './KvsQueryOperationType';
 
-export type KvsQueryOperation = {
+// Type for individual query conditions
+export type KvsQueryCondition = {
   key: string;
   operation: KvsQueryOperationType;
   valueA?: string | number | boolean;
   valueB?: string | number | boolean;
 };
+
+// Type for logical operators
+export type KvsLogicalOperator = {
+  operation: KvsLogicalOperatorType;
+  conditions: (KvsQueryCondition | KvsLogicalOperator)[];
+};
+
+// Type for the overall query operation
+export type KvsQueryOperation = KvsQueryCondition | KvsLogicalOperator;

--- a/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperation.ts
+++ b/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperation.ts
@@ -4,7 +4,7 @@ import { KvsQueryOperationType, KvsLogicalOperatorType } from './KvsQueryOperati
 export type KvsQueryCondition = {
   key: string;
   operation: KvsQueryOperationType;
-  valueA?: string | number | boolean;
+  valueA?: string | number | boolean | string[];
   valueB?: string | number | boolean;
 };
 

--- a/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperation.ts
+++ b/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperation.ts
@@ -1,0 +1,8 @@
+import { KvsQueryOperationType } from './KvsQueryOperationType';
+
+export type KvsQueryOperation = {
+  key: string;
+  operation: KvsQueryOperationType;
+  valueA?: string | number | boolean;
+  valueB?: string | number | boolean;
+};

--- a/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperationType.ts
+++ b/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperationType.ts
@@ -43,3 +43,18 @@ export enum KvsQueryOperationType {
   /** Corresponds to the DynamoDB 'NOT_CONTAINS' condition. */
   NotContains = 'NotContains',
 }
+
+/**
+ * Enum representing the logical operators for a key-value store query.
+ */
+export enum KvsLogicalOperatorType {
+  /**
+   * Represents the logical AND operator.
+   */
+  And = 'And',
+
+  /**
+   * Represents the logical OR operator.
+   */
+  Or = 'Or',
+}

--- a/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperationType.ts
+++ b/quidproquo-core/src/actions/keyValueStore/types/KvsQueryOperationType.ts
@@ -1,0 +1,45 @@
+/**
+ * The KvsQueryOperationType enum represents possible operations
+ * for a key-value store query.
+ * Each operation is annotated with its corresponding DynamoDB condition.
+ */
+export enum KvsQueryOperationType {
+  /** Corresponds to the DynamoDB 'EQ' condition. */
+  Equal = 'Equal',
+
+  /** Corresponds to the DynamoDB 'NE' condition. */
+  NotEqual = 'NotEqual',
+
+  /** Corresponds to the DynamoDB 'LT' condition. */
+  LessThan = 'LessThan',
+
+  /** Corresponds to the DynamoDB 'LE' condition. */
+  LessThanOrEqual = 'LessThanOrEqual',
+
+  /** Corresponds to the DynamoDB 'GT' condition. */
+  GreaterThan = 'GreaterThan',
+
+  /** Corresponds to the DynamoDB 'GE' condition. */
+  GreaterThanOrEqual = 'GreaterThanOrEqual',
+
+  /** Corresponds to the DynamoDB 'BETWEEN' condition. */
+  Between = 'Between',
+
+  /** Corresponds to the DynamoDB 'IN' condition. */
+  In = 'In',
+
+  /** Corresponds to the DynamoDB 'AttributeExists' condition. */
+  Exists = 'Exists',
+
+  /** Corresponds to the DynamoDB 'AttributeNotExists' condition. */
+  NotExists = 'NotExists',
+
+  /** Corresponds to the DynamoDB 'BEGINS_WITH' condition. */
+  BeginsWith = 'BeginsWith',
+
+  /** Corresponds to the DynamoDB 'CONTAINS' condition. */
+  Contains = 'Contains',
+
+  /** Corresponds to the DynamoDB 'NOT_CONTAINS' condition. */
+  NotContains = 'NotContains',
+}

--- a/quidproquo-core/src/actions/keyValueStore/types/index.ts
+++ b/quidproquo-core/src/actions/keyValueStore/types/index.ts
@@ -1,0 +1,2 @@
+export * from './KvsQueryOperation';
+export * from './KvsQueryOperationType';

--- a/quidproquo-core/src/actions/keyValueStore/utils/index.ts
+++ b/quidproquo-core/src/actions/keyValueStore/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './kvsExpression';

--- a/quidproquo-core/src/actions/keyValueStore/utils/kvsExpression.ts
+++ b/quidproquo-core/src/actions/keyValueStore/utils/kvsExpression.ts
@@ -1,0 +1,63 @@
+import { KvsQueryOperation, KvsQueryOperationType } from '../types';
+
+const kvsExpression = (
+  key: string,
+  operation: KvsQueryOperationType,
+  valueA?: KvsQueryOperation['valueA'],
+  valueB?: KvsQueryOperation['valueB'],
+): KvsQueryOperation => ({
+  key: key,
+  operation: operation,
+  valueA: valueA,
+  valueB: valueB,
+});
+
+export const kvsEqual = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.Equal, value);
+
+export const kvsNotEqual = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.NotEqual, value);
+
+export const kvsLessThan = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.LessThan, value);
+
+export const kvsLessThanOrEqual = (
+  key: string,
+  value: KvsQueryOperation['valueA'],
+): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.LessThanOrEqual, value);
+
+export const kvsGreaterThan = (
+  key: string,
+  value: KvsQueryOperation['valueA'],
+): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.GreaterThan, value);
+
+export const kvsGreaterThanOrEqual = (
+  key: string,
+  value: KvsQueryOperation['valueA'],
+): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.GreaterThanOrEqual, value);
+
+export const kvsBetween = (
+  key: string,
+  valueA: KvsQueryOperation['valueA'],
+  valueB: KvsQueryOperation['valueB'],
+): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.Between, valueA, valueB);
+
+export const kvsIn = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.In, value);
+
+export const kvsExists = (key: string): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.Exists);
+
+export const kvsNotExists = (key: string): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.NotExists);
+
+export const kvsBeginsWith = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.BeginsWith, value);
+
+export const kvsContains = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+  kvsExpression(key, KvsQueryOperationType.Contains, value);
+
+export const kvsNotContains = (
+  key: string,
+  value: KvsQueryOperation['valueA'],
+): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.NotContains, value);

--- a/quidproquo-core/src/actions/keyValueStore/utils/kvsExpression.ts
+++ b/quidproquo-core/src/actions/keyValueStore/utils/kvsExpression.ts
@@ -1,63 +1,83 @@
-import { KvsQueryOperation, KvsQueryOperationType } from '../types';
+import {
+  KvsQueryCondition,
+  KvsQueryOperationType,
+  KvsLogicalOperatorType,
+  KvsLogicalOperator,
+  KvsQueryOperation,
+} from '../types';
 
 const kvsExpression = (
   key: string,
   operation: KvsQueryOperationType,
-  valueA?: KvsQueryOperation['valueA'],
-  valueB?: KvsQueryOperation['valueB'],
-): KvsQueryOperation => ({
+  valueA?: KvsQueryCondition['valueA'],
+  valueB?: KvsQueryCondition['valueB'],
+): KvsQueryCondition => ({
   key: key,
   operation: operation,
   valueA: valueA,
   valueB: valueB,
 });
 
-export const kvsEqual = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+const kvsLogicalOperator = (
+  operation: KvsLogicalOperatorType,
+  conditions: KvsQueryOperation[],
+): KvsLogicalOperator => ({
+  operation,
+  conditions,
+});
+
+export const kvsEqual = (key: string, value: KvsQueryCondition['valueA']): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.Equal, value);
 
-export const kvsNotEqual = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+export const kvsNotEqual = (key: string, value: KvsQueryCondition['valueA']): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.NotEqual, value);
 
-export const kvsLessThan = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+export const kvsLessThan = (key: string, value: KvsQueryCondition['valueA']): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.LessThan, value);
 
 export const kvsLessThanOrEqual = (
   key: string,
-  value: KvsQueryOperation['valueA'],
-): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.LessThanOrEqual, value);
+  value: KvsQueryCondition['valueA'],
+): KvsQueryCondition => kvsExpression(key, KvsQueryOperationType.LessThanOrEqual, value);
 
 export const kvsGreaterThan = (
   key: string,
-  value: KvsQueryOperation['valueA'],
-): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.GreaterThan, value);
+  value: KvsQueryCondition['valueA'],
+): KvsQueryCondition => kvsExpression(key, KvsQueryOperationType.GreaterThan, value);
 
 export const kvsGreaterThanOrEqual = (
   key: string,
-  value: KvsQueryOperation['valueA'],
-): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.GreaterThanOrEqual, value);
+  value: KvsQueryCondition['valueA'],
+): KvsQueryCondition => kvsExpression(key, KvsQueryOperationType.GreaterThanOrEqual, value);
 
 export const kvsBetween = (
   key: string,
-  valueA: KvsQueryOperation['valueA'],
-  valueB: KvsQueryOperation['valueB'],
-): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.Between, valueA, valueB);
+  valueA: KvsQueryCondition['valueA'],
+  valueB: KvsQueryCondition['valueB'],
+): KvsQueryCondition => kvsExpression(key, KvsQueryOperationType.Between, valueA, valueB);
 
-export const kvsIn = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+export const kvsIn = (key: string, value: KvsQueryCondition['valueA']): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.In, value);
 
-export const kvsExists = (key: string): KvsQueryOperation =>
+export const kvsExists = (key: string): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.Exists);
 
-export const kvsNotExists = (key: string): KvsQueryOperation =>
+export const kvsNotExists = (key: string): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.NotExists);
 
-export const kvsBeginsWith = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+export const kvsBeginsWith = (key: string, value: KvsQueryCondition['valueA']): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.BeginsWith, value);
 
-export const kvsContains = (key: string, value: KvsQueryOperation['valueA']): KvsQueryOperation =>
+export const kvsContains = (key: string, value: KvsQueryCondition['valueA']): KvsQueryCondition =>
   kvsExpression(key, KvsQueryOperationType.Contains, value);
 
 export const kvsNotContains = (
   key: string,
-  value: KvsQueryOperation['valueA'],
-): KvsQueryOperation => kvsExpression(key, KvsQueryOperationType.NotContains, value);
+  value: KvsQueryCondition['valueA'],
+): KvsQueryCondition => kvsExpression(key, KvsQueryOperationType.NotContains, value);
+
+export const kvsAnd = (conditions: KvsQueryOperation[]): KvsLogicalOperator =>
+  kvsLogicalOperator(KvsLogicalOperatorType.And, conditions);
+
+export const kvsOr = (conditions: KvsQueryOperation[]): KvsLogicalOperator =>
+  kvsLogicalOperator(KvsLogicalOperatorType.Or, conditions);

--- a/quidproquo-core/src/config/settings/keyValueStore.ts
+++ b/quidproquo-core/src/config/settings/keyValueStore.ts
@@ -27,10 +27,12 @@ export const kvsKey = (key: string, type: KvsKeyType = 'string'): KvsKey => ({
 });
 
 type CompositeKvsKey = KvsKey | string;
-export type CompositeKvsIndex = {
-  partitionKey: CompositeKvsKey;
-  sortKey?: CompositeKvsKey;
-};
+export type CompositeKvsIndex =
+  | string
+  | {
+      partitionKey: CompositeKvsKey;
+      sortKey?: CompositeKvsKey;
+    };
 
 const convertCompositeKvsKeyToKvsKey = (compositeKvsKey: CompositeKvsKey): KvsKey => {
   if (typeof compositeKvsKey === 'string') {
@@ -40,12 +42,20 @@ const convertCompositeKvsKeyToKvsKey = (compositeKvsKey: CompositeKvsKey): KvsKe
   return compositeKvsKey;
 };
 
-const convertCompositeKvsIndexToKvsIndex = (compositeKvsIndex: CompositeKvsIndex): KvsIndex => ({
-  partitionKey: convertCompositeKvsKeyToKvsKey(compositeKvsIndex.partitionKey),
-  sortKey: compositeKvsIndex.sortKey
-    ? convertCompositeKvsKeyToKvsKey(compositeKvsIndex.sortKey)
-    : undefined,
-});
+const convertCompositeKvsIndexToKvsIndex = (compositeKvsIndex: CompositeKvsIndex): KvsIndex => {
+  if (typeof compositeKvsIndex === 'string') {
+    return {
+      partitionKey: kvsKey(compositeKvsIndex, 'string'),
+    };
+  }
+
+  return {
+    partitionKey: convertCompositeKvsKeyToKvsKey(compositeKvsIndex.partitionKey),
+    sortKey: compositeKvsIndex.sortKey
+      ? convertCompositeKvsKeyToKvsKey(compositeKvsIndex.sortKey)
+      : undefined,
+  };
+};
 
 export interface QPQConfigAdvancedKeyValueStoreSettings extends QPQConfigAdvancedSettings {
   indexes: CompositeKvsIndex[];

--- a/quidproquo-core/src/qpqCoreUtils.ts
+++ b/quidproquo-core/src/qpqCoreUtils.ts
@@ -186,6 +186,17 @@ export const getAllKeyValueStores = (qpqConfig: QPQConfig): KeyValueStoreQPQConf
   return keyValueStores;
 };
 
+export const getKeyValueStoreByName = (
+  qpqConfig: QPQConfig,
+  kvsName: string,
+): KeyValueStoreQPQConfigSetting | undefined => {
+  const keyValueStore = getAllKeyValueStores(qpqConfig).find(
+    (kvs) => kvs.keyValueStoreName === kvsName,
+  );
+
+  return keyValueStore;
+};
+
 export const getActionProcessorSources = (configs: QPQConfig): string[] => {
   const sources = getConfigSettings<ActionProcessorsQPQConfigSetting>(
     configs,

--- a/quidproquo-deploy-awscdk/src/lambdas/lambda-utils/getLambdaActionProcessors.ts
+++ b/quidproquo-deploy-awscdk/src/lambdas/lambda-utils/getLambdaActionProcessors.ts
@@ -1,0 +1,52 @@
+import { QPQConfig } from 'quidproquo-core';
+
+import {
+  coreActionProcessor,
+  webserverActionProcessor,
+  getConfigActionProcessor,
+} from 'quidproquo-actionprocessor-node';
+
+import {
+  getSystemActionProcessor,
+  getFileActionProcessor,
+  getQueueActionProcessor,
+  getEventBusActionProcessor,
+  getConfigGetSecretActionProcessor,
+  getConfigGetParameterActionProcessor,
+  getConfigGetParametersActionProcessor,
+  getUserDirectoryActionProcessor,
+  getWebEntryActionProcessor,
+  getServiceFunctionActionProcessor,
+  getAdminActionProcessor,
+  getKeyValueStoreActionProcessor,
+} from 'quidproquo-actionprocessor-awslambda';
+
+import { dynamicModuleLoader } from '../dynamicModuleLoader';
+
+// @ts-ignore - Special webpack loader
+import qpqCustomActionProcessors from 'qpq-custom-action-processors-loader!';
+
+export const getLambdaActionProcessors = (qpqConfig: QPQConfig) => {
+  const storyActionProcessor = {
+    ...coreActionProcessor,
+    ...webserverActionProcessor,
+
+    ...getConfigGetSecretActionProcessor(qpqConfig),
+    ...getConfigGetParameterActionProcessor(qpqConfig),
+    ...getConfigGetParametersActionProcessor(qpqConfig),
+    ...getSystemActionProcessor(qpqConfig, dynamicModuleLoader),
+    ...getFileActionProcessor(qpqConfig),
+    ...getConfigActionProcessor(qpqConfig),
+    ...getQueueActionProcessor(qpqConfig),
+    ...getEventBusActionProcessor(qpqConfig),
+    ...getUserDirectoryActionProcessor(qpqConfig),
+    ...getWebEntryActionProcessor(qpqConfig),
+    ...getServiceFunctionActionProcessor(qpqConfig),
+    ...getAdminActionProcessor(qpqConfig),
+    ...getKeyValueStoreActionProcessor(qpqConfig),
+
+    ...qpqCustomActionProcessors(),
+  };
+
+  return storyActionProcessor;
+};

--- a/quidproquo-deploy-awscdk/src/lambdas/lambda-utils/index.ts
+++ b/quidproquo-deploy-awscdk/src/lambdas/lambda-utils/index.ts
@@ -1,2 +1,3 @@
 export * from './getRuntimeCorrelation';
 export * from './logger';
+export * from './getLambdaActionProcessors';

--- a/quidproquo-deploy-awscdk/src/lambdas/lambdaAPIGatewayEvent.ts
+++ b/quidproquo-deploy-awscdk/src/lambdas/lambdaAPIGatewayEvent.ts
@@ -1,24 +1,4 @@
-import {
-  coreActionProcessor,
-  webserverActionProcessor,
-  getConfigActionProcessor,
-} from 'quidproquo-actionprocessor-node';
-
-import {
-  getAPIGatewayEventActionProcessor,
-  getSystemActionProcessor,
-  getFileActionProcessor,
-  getQueueActionProcessor,
-  getEventBusActionProcessor,
-  getConfigGetSecretActionProcessor,
-  getConfigGetParameterActionProcessor,
-  getConfigGetParametersActionProcessor,
-  getUserDirectoryActionProcessor,
-  getWebEntryActionProcessor,
-  getServiceFunctionActionProcessor,
-  getAdminActionProcessor,
-  awsLambdaUtils,
-} from 'quidproquo-actionprocessor-awslambda';
+import { getAPIGatewayEventActionProcessor } from 'quidproquo-actionprocessor-awslambda';
 
 import { qpqWebServerUtils } from 'quidproquo-webserver';
 
@@ -29,9 +9,7 @@ import { APIGatewayEvent, Context } from 'aws-lambda';
 import { getLambdaConfigs } from './lambdaConfig';
 import { ActionProcessorListResolver } from './actionProcessorListResolver';
 
-import { getLogger, getRuntimeCorrelation } from './lambda-utils';
-
-import { dynamicModuleLoader } from './dynamicModuleLoader';
+import { getLogger, getRuntimeCorrelation, getLambdaActionProcessors } from './lambda-utils';
 
 // @ts-ignore - Special webpack loader
 import qpqCustomActionProcessors from 'qpq-custom-action-processors-loader!';
@@ -65,24 +43,9 @@ export const getAPIGatewayEventExecutor = (
     // Build a processor for the session and stuff
     // Remove the non route ones ~ let the story execute action add them
     const storyActionProcessor = {
-      ...coreActionProcessor,
-      ...webserverActionProcessor,
-
+      ...getLambdaActionProcessors(cdkConfig.qpqConfig),
       ...getAPIGatewayEventActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetSecretActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParameterActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParametersActionProcessor(cdkConfig.qpqConfig),
-      ...getSystemActionProcessor(cdkConfig.qpqConfig, dynamicModuleLoader),
-      ...getFileActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigActionProcessor(cdkConfig.qpqConfig),
-      ...getQueueActionProcessor(cdkConfig.qpqConfig),
-      ...getEventBusActionProcessor(cdkConfig.qpqConfig),
-      ...getUserDirectoryActionProcessor(cdkConfig.qpqConfig),
-      ...getWebEntryActionProcessor(cdkConfig.qpqConfig),
-      ...getServiceFunctionActionProcessor(cdkConfig.qpqConfig),
-      ...getAdminActionProcessor(cdkConfig.qpqConfig),
 
-      ...getCustomActionProcessors(cdkConfig.qpqConfig),
       ...qpqCustomActionProcessors(),
     };
 

--- a/quidproquo-deploy-awscdk/src/lambdas/lambdaEventBridgeEvent.ts
+++ b/quidproquo-deploy-awscdk/src/lambdas/lambdaEventBridgeEvent.ts
@@ -1,22 +1,5 @@
 import {
-  coreActionProcessor,
-  webserverActionProcessor,
-  getConfigActionProcessor,
-} from 'quidproquo-actionprocessor-node';
-
-import {
   getEventBridgeEventActionProcessor,
-  getSystemActionProcessor,
-  getFileActionProcessor,
-  getQueueActionProcessor,
-  getEventBusActionProcessor,
-  getWebEntryActionProcessor,
-  getUserDirectoryActionProcessor,
-  getConfigGetSecretActionProcessor,
-  getConfigGetParameterActionProcessor,
-  getConfigGetParametersActionProcessor,
-  getServiceFunctionActionProcessor,
-  getAdminActionProcessor,
   DynamicModuleLoader,
   LambdaRuntimeConfig,
 } from 'quidproquo-actionprocessor-awslambda';
@@ -27,7 +10,7 @@ import { EventBridgeEvent, Context } from 'aws-lambda';
 
 import { getLambdaConfigs } from './lambdaConfig';
 import { ActionProcessorListResolver } from './actionProcessorListResolver';
-import { getLogger, getRuntimeCorrelation } from './lambda-utils';
+import { getLogger, getRuntimeCorrelation, getLambdaActionProcessors } from './lambda-utils';
 
 import { dynamicModuleLoader } from './dynamicModuleLoader';
 
@@ -51,24 +34,9 @@ export const getEventBridgeEventExecutor = (
     // Build a processor for the session and stuff
     // Remove the  non event ones
     const storyActionProcessor = {
-      ...coreActionProcessor,
-      ...webserverActionProcessor,
-
+      ...getLambdaActionProcessors(cdkConfig.qpqConfig),
       ...getEventBridgeEventActionProcessor(lambdaRuntimeConfig),
-      ...getSystemActionProcessor(cdkConfig.qpqConfig, dynamicModuleLoader),
-      ...getFileActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetSecretActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParameterActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParametersActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigActionProcessor(cdkConfig.qpqConfig),
-      ...getQueueActionProcessor(cdkConfig.qpqConfig),
-      ...getEventBusActionProcessor(cdkConfig.qpqConfig),
-      ...getWebEntryActionProcessor(cdkConfig.qpqConfig),
-      ...getServiceFunctionActionProcessor(cdkConfig.qpqConfig),
-      ...getAdminActionProcessor(cdkConfig.qpqConfig),
-      ...getUserDirectoryActionProcessor(cdkConfig.qpqConfig),
 
-      ...getCustomActionProcessors(cdkConfig.qpqConfig),
       ...qpqCustomActionProcessors(),
     };
 

--- a/quidproquo-deploy-awscdk/src/lambdas/lambdaEventOriginRequest.ts
+++ b/quidproquo-deploy-awscdk/src/lambdas/lambdaEventOriginRequest.ts
@@ -1,21 +1,5 @@
 import {
-  coreActionProcessor,
-  webserverActionProcessor,
-  getConfigActionProcessor,
-} from 'quidproquo-actionprocessor-node';
-
-import {
   getCloudFrontOriginRequestEventActionProcessor,
-  getSystemActionProcessor,
-  getFileActionProcessor,
-  getUserDirectoryActionProcessor,
-  getConfigGetSecretActionProcessor,
-  getConfigGetParameterActionProcessor,
-  getConfigGetParametersActionProcessor,
-  getWebEntryActionProcessor,
-  getServiceFunctionActionProcessor,
-  getAdminActionProcessor,
-  awsLambdaUtils,
   DynamicModuleLoader,
 } from 'quidproquo-actionprocessor-awslambda';
 
@@ -26,7 +10,7 @@ import { createRuntime, askProcessEvent, QpqRuntimeType } from 'quidproquo-core'
 import { CloudFrontRequestEvent, CloudFrontRequestResult, Context } from 'aws-lambda';
 
 import { ActionProcessorListResolver } from './actionProcessorListResolver';
-import { getLogger, getRuntimeCorrelation } from './lambda-utils';
+import { getLogger, getRuntimeCorrelation, getLambdaActionProcessors } from './lambda-utils';
 
 import { dynamicModuleLoader } from './dynamicModuleLoader';
 
@@ -48,24 +32,9 @@ export const getOriginRequestEventExecutor = (
     // Build a processor for the session and stuff
     // Remove the non route ones ~ let the story execute action add them
     const storyActionProcessor = {
-      ...coreActionProcessor,
-      ...webserverActionProcessor,
-
+      ...getLambdaActionProcessors(cdkConfig.qpqConfig),
       ...getCloudFrontOriginRequestEventActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetSecretActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParameterActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParametersActionProcessor(cdkConfig.qpqConfig),
-      ...getSystemActionProcessor(cdkConfig.qpqConfig, dynamicModuleLoader),
-      ...getFileActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigActionProcessor(cdkConfig.qpqConfig),
-      ...getWebEntryActionProcessor(cdkConfig.qpqConfig),
-      ...getServiceFunctionActionProcessor(cdkConfig.qpqConfig),
-      ...getAdminActionProcessor(cdkConfig.qpqConfig),
 
-      // We probably don't want this?
-      ...getUserDirectoryActionProcessor(cdkConfig.qpqConfig),
-
-      ...getCustomActionProcessors(cdkConfig.qpqConfig),
       ...qpqCustomActionProcessors(),
     };
 

--- a/quidproquo-deploy-awscdk/src/lambdas/lambdaSQSEvent.ts
+++ b/quidproquo-deploy-awscdk/src/lambdas/lambdaSQSEvent.ts
@@ -1,25 +1,9 @@
 import { SQSEvent, SQSBatchResponse, Context } from 'aws-lambda';
 
-import { coreActionProcessor, webserverActionProcessor } from 'quidproquo-actionprocessor-node';
-
 import {
   getSQSEventRecordActionProcessor,
-  getSystemActionProcessor,
-  getFileActionProcessor,
-  getQueueActionProcessor,
-  getEventBusActionProcessor,
-  getConfigGetSecretActionProcessor,
-  getConfigGetParameterActionProcessor,
-  getConfigGetParametersActionProcessor,
-  getUserDirectoryActionProcessor,
-  getWebEntryActionProcessor,
-  getServiceFunctionActionProcessor,
-  getAdminActionProcessor,
-  awsLambdaUtils,
   DynamicModuleLoader,
 } from 'quidproquo-actionprocessor-awslambda';
-
-import { getConfigActionProcessor } from 'quidproquo-actionprocessor-node';
 
 import { getLambdaConfigs } from './lambdaConfig';
 
@@ -32,7 +16,7 @@ import {
 } from 'quidproquo-core';
 
 import { ActionProcessorListResolver } from './actionProcessorListResolver';
-import { getLogger, getRuntimeCorrelation } from './lambda-utils';
+import { getLogger, getRuntimeCorrelation, getLambdaActionProcessors } from './lambda-utils';
 
 import { dynamicModuleLoader } from './dynamicModuleLoader';
 
@@ -57,24 +41,10 @@ export const getStoryActionRuntime = async (
   // Build a processor for the session and stuff
   // Remove the non route ones ~ let the story execute action add them
   const storyActionProcessor = {
-    ...coreActionProcessor,
-    ...webserverActionProcessor,
+    ...getLambdaActionProcessors(cdkConfig.qpqConfig),
 
     ...getSQSEventRecordActionProcessor(cdkConfig.qpqConfig),
-    ...getConfigGetSecretActionProcessor(cdkConfig.qpqConfig),
-    ...getConfigGetParameterActionProcessor(cdkConfig.qpqConfig),
-    ...getConfigGetParametersActionProcessor(cdkConfig.qpqConfig),
-    ...getSystemActionProcessor(cdkConfig.qpqConfig, dynamicModuleLoader),
-    ...getFileActionProcessor(cdkConfig.qpqConfig),
-    ...getConfigActionProcessor(cdkConfig.qpqConfig),
-    ...getQueueActionProcessor(cdkConfig.qpqConfig),
-    ...getEventBusActionProcessor(cdkConfig.qpqConfig),
-    ...getUserDirectoryActionProcessor(cdkConfig.qpqConfig),
-    ...getWebEntryActionProcessor(cdkConfig.qpqConfig),
-    ...getServiceFunctionActionProcessor(cdkConfig.qpqConfig),
-    ...getAdminActionProcessor(cdkConfig.qpqConfig),
 
-    ...getCustomActionProcessors(cdkConfig.qpqConfig),
     ...qpqCustomActionProcessors(),
   };
 

--- a/quidproquo-deploy-awscdk/src/lambdas/lambdaServiceFunctionExecute.ts
+++ b/quidproquo-deploy-awscdk/src/lambdas/lambdaServiceFunctionExecute.ts
@@ -1,24 +1,7 @@
-import {
-  coreActionProcessor,
-  webserverActionProcessor,
-  getConfigActionProcessor,
-} from 'quidproquo-actionprocessor-node';
 import { ExecuteServiceFunctionEvent } from 'quidproquo-webserver';
 
 import {
   getServiceFunctionExecuteEventActionProcessor,
-  getSystemActionProcessor,
-  getFileActionProcessor,
-  getQueueActionProcessor,
-  getEventBusActionProcessor,
-  getConfigGetSecretActionProcessor,
-  getConfigGetParameterActionProcessor,
-  getConfigGetParametersActionProcessor,
-  getUserDirectoryActionProcessor,
-  getWebEntryActionProcessor,
-  getServiceFunctionActionProcessor,
-  getAdminActionProcessor,
-  awsLambdaUtils,
   DynamicModuleLoader,
 } from 'quidproquo-actionprocessor-awslambda';
 
@@ -28,7 +11,7 @@ import { Context } from 'aws-lambda';
 
 import { getLambdaConfigs } from './lambdaConfig';
 import { ActionProcessorListResolver } from './actionProcessorListResolver';
-import { getLogger, getRuntimeCorrelation } from './lambda-utils';
+import { getLogger, getRuntimeCorrelation, getLambdaActionProcessors } from './lambda-utils';
 
 // @ts-ignore - Special webpack loader
 import { dynamicModuleLoader } from './dynamicModuleLoader';
@@ -54,25 +37,9 @@ export const getServiceFunctionExecuteEventExecutor = (
     // Build a processor for the session and stuff
     // Remove the non route ones ~ let the story execute action add them
     const storyActionProcessor = {
-      ...coreActionProcessor,
-      ...webserverActionProcessor,
-
+      ...getLambdaActionProcessors(cdkConfig.qpqConfig),
       ...getServiceFunctionExecuteEventActionProcessor(cdkConfig.qpqConfig),
 
-      ...getConfigGetSecretActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParameterActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigGetParametersActionProcessor(cdkConfig.qpqConfig),
-      ...getSystemActionProcessor(cdkConfig.qpqConfig, dynamicModuleLoader),
-      ...getFileActionProcessor(cdkConfig.qpqConfig),
-      ...getConfigActionProcessor(cdkConfig.qpqConfig),
-      ...getQueueActionProcessor(cdkConfig.qpqConfig),
-      ...getEventBusActionProcessor(cdkConfig.qpqConfig),
-      ...getUserDirectoryActionProcessor(cdkConfig.qpqConfig),
-      ...getWebEntryActionProcessor(cdkConfig.qpqConfig),
-      ...getServiceFunctionActionProcessor(cdkConfig.qpqConfig),
-      ...getAdminActionProcessor(cdkConfig.qpqConfig),
-
-      ...getCustomActionProcessors(cdkConfig.qpqConfig),
       ...qpqCustomActionProcessors(),
     };
 

--- a/quidproquo-deploy-awscdk/src/utils/qpqDeployAwsCdkUtils.ts
+++ b/quidproquo-deploy-awscdk/src/utils/qpqDeployAwsCdkUtils.ts
@@ -10,6 +10,7 @@ import {
   SecretQPQConfigSetting,
   QPQConfig,
   QueueQPQConfigSetting,
+  KeyValueStoreQPQConfigSetting,
 } from 'quidproquo-core';
 
 import {
@@ -27,6 +28,7 @@ import {
   QpqCoreQueueConstruct,
   QpqCoreUserDirectoryConstruct,
   QpqCoreEventBusConstruct,
+  QpqCoreKeyValueStoreConstruct,
   LogStorage,
 } from '../constructs';
 
@@ -54,6 +56,27 @@ export const getQqpSecretGrantables = (
   });
 
   return secretResources;
+};
+
+export const getQqpKvsGrantables = (
+  scope: Construct,
+  id: string,
+  qpqConfig: QPQConfig,
+  awsAccountId: string,
+): QpqResource[] => {
+  const kvsSettings = [...qpqCoreUtils.getAllKeyValueStores(qpqConfig)];
+
+  const kvsResources = kvsSettings.map((kvsSetting) => {
+    return QpqCoreKeyValueStoreConstruct.fromOtherStack(
+      scope,
+      `${id}-${qpqCoreUtils.getUniqueKeyForSetting(kvsSetting)}-grantable`,
+      qpqConfig,
+      awsAccountId,
+      kvsSetting.keyValueStoreName,
+    );
+  });
+
+  return kvsResources;
 };
 
 export const getQqpParameterGrantables = (
@@ -259,6 +282,7 @@ export const getQqpGrantableResources = (
     ...getQqpUserPoolGrantables(scope, id, qpqConfig, awsAccountId),
     ...getQqpTopicGrantables(scope, id, qpqConfig, awsAccountId),
     ...getQqpServiceLogGrantables(scope, id, qpqConfig, awsAccountId),
+    ...getQqpKvsGrantables(scope, id, qpqConfig, awsAccountId),
   ];
 };
 


### PR DESCRIPTION
# Merge Request - KeyValueStore Support into QuidProQuo

This MR integrates KeyValueStore (KVS) support into QuidProQuo, enabling Upsert, Scan, and Query operations using a new KVS ORM (Object-Relational Mapping). The ORM simplifies interaction with the KVS and abstracts the complexity of the underlying operations.

## Features

1. Types for individual query conditions.
2. Types for logical operators.
3. Types for the overall query operation.
4. Enum representation for key-value store query operations.
5. Enum representation for logical operators in a key-value store query.
6. ORM functions for interaction with the key-value store.

### Code Example

Below is an example of how to use the KVS ORM:

```typescript
import {
  kvsEqual,
  kvsLessThan,
  kvsAnd,
} from 'quidproquo-core';

// To create a query
const query = kvsAnd([
  kvsEqual('name', 'John Doe'),
  kvsLessThan('age', 30),
]);
```

## Changelog

- Commit: `5bf1b52fc5bd7ba06bac522a535f8a74c1bd416f`: Bump: KVS Basic features.
- Commit: `85ea2dc7bdc35151357af895a54c13588eb13755`: Removed some console logs.
- Commit: `2ad0e8dd1f49ffd63162c815da675930854ccc71`: Added scan action.
- Commit: `e007dd4902ca1552d53e63abadfd1e619f02d8d6`: KVS Get / Upsert working.
- Commit: `e58e7d7caa529a5e6350789ae8d980db29b97137`: Exposed permissions.
- Commit: `cf28afecb6925632396c43f30223410070f57b26`: Wip: Query.
- Commit: `da717e5afa464f125f370f81c7eb7060a7391099`: KVS Query action.
- Commit: `4c579a6c03674cd1ae0d70d92a91e726ab296ed5`: Upsert item.

